### PR TITLE
Fix javadoc

### DIFF
--- a/src/main/java/ie/googlielmo/publishtokafka/PublishToKafkaBuilder.java
+++ b/src/main/java/ie/googlielmo/publishtokafka/PublishToKafkaBuilder.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * {@link DescriptorImpl#newInstance(StaplerRequest)} is invoked
  * and a new {@link PublishToKafkaBuilder} is created. The created
  * instance is persisted to the project configuration XML by using
- * XStream, so this allows you to use instance fields (like {@link #name})
+ * XStream, so this allows you to use instance fields (like {@link #topic})
  * to remember the configuration.
  *
  * <p>

--- a/src/main/java/ie/googlielmo/publishtokafka/kafka/SimpleKafkaProducer.java
+++ b/src/main/java/ie/googlielmo/publishtokafka/kafka/SimpleKafkaProducer.java
@@ -17,6 +17,7 @@ public class SimpleKafkaProducer {
     
 	/**
 	 * Default constructor.
+	 * @param producerConfig The configuration
 	 */
 	public SimpleKafkaProducer(KafkaProducerConfiguration producerConfig) {
 		init(producerConfig);


### PR DESCRIPTION
`mvn compile` complains about javadoc beeing wrong.

I'm not sure replacing "name" by "topic" respects the initial meaning of your documentation but it seems the better match.

This PR contains no changes in code, only documentation.